### PR TITLE
fix: update redirect logic in Navbar and AuthProvider

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ const Navbar = () => {
 
   const handleSignOut = async () => {
     await signOut();
-    window.location.href = "/";
+    window.location.href = "/signin";
   };
 
   return (


### PR DESCRIPTION
- Changed sign-out redirect in Navbar from '/' to '/signin'
- Updated AuthProvider to fetch user attributes after sign-in
  and redirect based on custom:role (manager/tenant)
